### PR TITLE
Add a check to ensure the codeblock insertion is within the content div.

### DIFF
--- a/ray-editor.js
+++ b/ray-editor.js
@@ -336,6 +336,7 @@ class RayEditor {
    #insertCodeBlock() {
    const selection = window.getSelection();
    if (!selection.rangeCount) return;
+   if (!this.editorArea.contains(selection.anchorNode)) return; //check that codeblock is within the editor region.
 
    const range = selection.getRangeAt(0);
 


### PR DESCRIPTION
This fixes an issue where the code block element gets added to wherever you last clicked on the page rather than in the content area.

Before: 
![image](https://github.com/user-attachments/assets/daca282a-8c86-4cd6-bbfd-f56d1bbec02a)

After: 
![image](https://github.com/user-attachments/assets/0082b268-a133-4907-bbaf-8d456c08204a)


